### PR TITLE
added nix flake for nix developers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake . --impure

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ workspace/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.direnv
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1748047550,
+        "narHash": "sha256-t0qLLqb4C1rdtiY8IFRH5KIapTY/n3Lqt57AmxEv9mk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b718a78696060df6280196a6f992d04c87a16aef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748792178,
+        "narHash": "sha256-BHmgfHlCJVNisJShVaEmfDIr/Ip58i/4oFGlD1iK6lk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5929de975bcf4c7c8d8b5ca65c8cd9ef9e44523e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1748832016,
+        "narHash": "sha256-TQSaFa1wWJr6GOs+K8lecK4AKKr8k6mwxHIPCOmVkgs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7ec2ea005b600dac9436a7c5c6b66d960cbfcea2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "A development shell for rust";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    crane.url = "github:ipetkov/crane";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    nixpkgs,
+    rust-overlay,
+    crane,
+    treefmt-nix,
+    ...
+  }: let
+    # Define systems
+    systems = [
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+
+    # Helper function to generate per-system attributes
+    forAllSystems = f: nixpkgs.lib.genAttrs systems f;
+  in {
+    # Optional: Define packages if using crane to build (uncomment to use)
+    # packages = forAllSystems (system: let
+    #   pkgs = import nixpkgs {
+    #     inherit system;
+    #     overlays = [rust-overlay.overlays.default];
+    #   };
+    #   craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.latest.default);
+    # in {
+    #   default = craneLib.buildPackage {
+    #     src = craneLib.cleanCargoSource ./.;
+    #     strictDeps = true;
+    #   };
+    # });
+
+    # Define devShells for all systems
+    devShells = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [rust-overlay.overlays.default];
+      };
+      # Optional: Initialize crane for building packages
+      # craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.latest.default);
+      # Optional: Example crane package build (uncomment to use)
+      # my-crate = craneLib.buildPackage {
+      #   src = craneLib.cleanCargoSource ./.;
+      #   strictDeps = true;
+      # };
+    in {
+      default = pkgs.mkShell {
+        name = "dev";
+        # Available packages on https://search.nixos.org/packages
+        buildInputs = with pkgs; [
+          alejandra # Nix
+          nixd
+          statix
+          deadnix
+          just
+          rust-bin.stable.latest.default
+          rust-analyzer
+          clippy
+        ];
+        shellHook = ''
+          echo "Welcome to the rust devshell!"
+        '';
+      };
+    });
+
+    formatter = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [rust-overlay.overlays.default];
+      };
+      treefmtModule = {
+        projectRootFile = "flake.nix";
+        programs = {
+          alejandra.enable = true; # Nix formatter
+          rustfmt.enable = true; # Rust formatter
+        };
+      };
+    in
+      treefmt-nix.lib.mkWrapper pkgs treefmtModule);
+  };
+}


### PR DESCRIPTION
This pull request introduces a Nix-based development environment for Rust projects. The key changes include adding a `flake.nix` file to define the environment and updating the `.envrc` file to use the Nix flake. These changes provide a reproducible and standardized setup for developers working on Rust.

### Nix-based development environment:

* **Added `flake.nix` file**: Defines a development shell for Rust with support for multiple systems (`x86_64-linux`, `aarch64-darwin`, `x86_64-darwin`). It includes dependencies such as `rust-bin`, `rust-analyzer`, `clippy`, and other developer tools. The file also sets up a formatter using `treefmt-nix` for Nix and Rust files.
* **Updated `.envrc` file**: Configured to use the Nix flake with the `--impure` flag, enabling the development environment defined in `flake.nix`.