### PR TITLE
feat: add from_pool constructor for PostgresDatabase

### DIFF
--- a/taitan-orm/src/database/mysql/database.rs
+++ b/taitan-orm/src/database/mysql/database.rs
@@ -1,6 +1,6 @@
 use super::transaction::MySqlTransaction;
 
-use sqlx::{MySql, MySqlPool};
+use sqlx::{MySql, MySqlPool, PgPool};
 use taitan_orm_trait::result::Result;
 use taitan_orm_trait::result::CountResult;
 use crate::executors::SqlExecutor;
@@ -20,6 +20,10 @@ impl MySqlDatabase {
 
     pub fn get_pool(&self) -> Result<&MySqlPool> {
         Ok(&self.pool)
+    }
+
+    pub fn from_pool(pool: MySqlPool) -> Self {
+        Self { pool }
     }
 }
 

--- a/taitan-orm/src/database/postgres/database.rs
+++ b/taitan-orm/src/database/postgres/database.rs
@@ -1,11 +1,11 @@
 use super::transaction::PostgresTransaction;
-use taitan_orm_trait::result::CountResult;
 use crate::brave_new_executor_impl;
+use crate::executors::SqlExecutor;
 use crate::executors::SqlGenericExecutor;
 use sqlx::PgPool;
 use sqlx::Postgres;
+use taitan_orm_trait::result::CountResult;
 use taitan_orm_trait::result::Result;
-use crate::executors::SqlExecutor;
 
 #[derive(Debug, Clone)]
 pub struct PostgresDatabase {
@@ -22,6 +22,10 @@ impl PostgresDatabase {
     pub fn get_pool(&self) -> Result<&PgPool> {
         Ok(&self.pool)
     }
+
+    pub fn from_pool(pool: PgPool) -> Self {
+        Self { pool }
+    }
 }
 
 impl SqlGenericExecutor for PostgresDatabase {
@@ -32,7 +36,6 @@ impl SqlGenericExecutor for PostgresDatabase {
         query_result.rows_affected()
     }
 }
-
 
 impl SqlExecutor<Postgres> for PostgresDatabase {
     brave_new_executor_impl!(sqlx::Postgres);

--- a/taitan-orm/src/database/sqlite/database.rs
+++ b/taitan-orm/src/database/sqlite/database.rs
@@ -1,10 +1,10 @@
 use super::transaction::SqliteTransaction;
 use crate::brave_new_executor_impl;
-use taitan_orm_trait::result::CountResult;
 use crate::executors::SqlExecutor;
 use crate::executors::SqlGenericExecutor;
-use sqlx::SqlitePool;
 use sqlx::Sqlite;
+use sqlx::SqlitePool;
+use taitan_orm_trait::result::CountResult;
 use taitan_orm_trait::result::Result;
 
 #[derive(Debug, Clone)]
@@ -22,8 +22,11 @@ impl SqliteDatabase {
     pub fn get_pool(&self) -> Result<&SqlitePool> {
         Ok(&self.sqlite_pool)
     }
-}
 
+    pub fn from_pool(pool: SqlitePool) -> Self {
+        Self { sqlite_pool: pool }
+    }
+}
 
 impl SqlGenericExecutor for SqliteDatabase {
     type DB = Sqlite;
@@ -33,7 +36,6 @@ impl SqlGenericExecutor for SqliteDatabase {
         query_result.rows_affected()
     }
 }
-
 
 impl SqlExecutor<Sqlite> for SqliteDatabase {
     brave_new_executor_impl!(sqlx::Sqlite);


### PR DESCRIPTION
When using PostgreSQL, I need to set the session time zone via after_connect, which requires control over how the PgPool is created. To support this, I added a from_pool constructor that allows injecting a pre-built connection pool.

Although this requirement currently applies only to PostgreSQL, I added the same from_pool method to other database implementations as well, for consistency across the API.